### PR TITLE
Bugfix release v0.2.1 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,7 +53,7 @@ Remotes:
     github::kwb-r/kwb.utils,
     github::Lchiffon/wordcloud2,
     github::ropensci/codemetar@v0.3.0,
-    github::UptakeOpenSource/pkgnet@d1e974de299d46e71b082e027a71b8b254edc9b2
+    github::uptake/pkgnet@d1e974de299d46e71b082e027a71b8b254edc9b2
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# [pkgmeta 0.2.1](https://github.com/KWB-R/pkgmeta/releases/tag/v0.2.1) <small>2022-06-01</small>
+
+* Bugfix: due to renamed organisation (formerly: `UptakeOpenSource`, now: `uptake`)
+of  [pkgnet](https://github.com/uptake/pkgnet) dependency (thanks to [@jeroen](https://github.com/r-universe-org/help/issues/169#issuecomment-1144111228))
+
+
 # [pkgmeta 0.2.0](https://github.com/KWB-R/pkgmeta/releases/tag/v0.2.0) <small>2022-06-01</small>
 
 * Harmonise with [kwb.pkgbuild](https://github.com/kwb-r/kwb.pkgbuild)


### PR DESCRIPTION
due to changed name of GitHub organisation for dependency pkgnet, Many thanks to @jeroen for spoting this (https://github.com/r-universe-org/help/issues/169)

While `remotes` is able to handle this renaming, this currently seems to be an issue for r-universe sync

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kwb-r/pkgmeta/13)
<!-- Reviewable:end -->
